### PR TITLE
Update dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,11 +12,11 @@
     "url": "git://github.com/paf31/purescript-with-index.git"
   },
   "dependencies": {
-    "purescript-monoid": "^3.3.0",
-    "purescript-newtype": "^2.0.0"
+    "purescript-newtype": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0",
-    "purescript-maps": "^3.5.2"
+    "purescript-psci-support": "^4.0.0",
+    "purescript-ordered-collections": "^1.6.1",
+    "purescript-tuples": "^5.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "git://github.com/paf31/purescript-with-index.git"
+    "url": "https://github.com/paf31/purescript-with-index.git"
   },
   "dependencies": {
     "purescript-newtype": "^3.0.0"

--- a/src/Data/WithIndex.purs
+++ b/src/Data/WithIndex.purs
@@ -32,7 +32,6 @@ module Data.WithIndex
 
 import Prelude
 
-import Data.Monoid (class Monoid, mempty)
 import Data.Newtype (class Newtype)
 
 -- | A wrapper for a mapping or traversal function which uses an index.
@@ -66,7 +65,7 @@ instance semigroupoidWithIndex :: Semigroup i => Semigroupoid (WithIndex i) wher
   compose (WithIndex f) (WithIndex g) = WithIndex \b -> f \i1 -> g \i2 -> b (i1 <> i2)
 
 instance categoryWithIndex :: Monoid i => Category (WithIndex i) where
-  id = WithIndex \i -> i mempty
+  identity = WithIndex \i -> i mempty
 
 -- | Change the `Monoid` used to combine indices.
 -- |

--- a/src/Data/WithIndex.purs
+++ b/src/Data/WithIndex.purs
@@ -39,14 +39,14 @@ import Data.Newtype (class Newtype)
 -- | For example, using the `Data.Map` module:
 -- |
 -- | ```purescript
--- | WithIndex mapWithKey
+-- | WithIndex mapWithIndex
 -- |   :: WithIndex i (a -> b) (Map i a -> Map i b)
 -- | ```
 -- |
 -- | These wrapped functions can be composed using the composition operator:
 -- |
 -- | ```purescript
--- | WithIndex mapWithKey . WithIndex mapWithKey
+-- | WithIndex mapWithIndex . WithIndex mapWithIndex
 -- |   :: Monoid i =>
 -- |      WithIndex i (a -> b) (Map i (Map i a) -> Map i (Map i b))
 -- | ```
@@ -54,7 +54,7 @@ import Data.Newtype (class Newtype)
 -- | and then applied using `withIndex`:
 -- |
 -- | ```purescript
--- | withIndex $ WithIndex mapWithKey . WithIndex mapWithKey
+-- | withIndex $ WithIndex mapWithIndex . WithIndex mapWithIndex
 -- |   :: Monoid i => (i -> a -> b) -> Map i (Map i a) -> Map i (Map i b)
 -- | ```
 newtype WithIndex i a b = WithIndex ((i -> a) -> b)
@@ -91,7 +91,7 @@ reindex ij (WithIndex f) = WithIndex \a -> f (a <<< ij)
 -- | For example, to traverse two layers, keeping only the first index:
 -- |
 -- | ```purescript
--- | WithIndex mapWithKey . withoutIndex map
+-- | WithIndex mapWithIndex . withoutIndex map
 -- |   :: Monoid i =>
 -- |      WithIndex i (a -> b) (Map i (Map k a) -> Map i (Map k b))
 -- | ```


### PR DESCRIPTION
This PR updates the dependencies to remove the dependence on deprecated packages. 

- [`purescript-monoid`](https://github.com/purescript-deprecated/purescript-monoid) has been deprecated as the functionality has been merged into the `Prelude`.
- [`purescript-maps`](https://github.com/purescript-deprecated/purescript-maps) has been deprecated in favor of [`purescript-ordered-collections`](https://github.com/purescript/purescript-ordered-collections)
- [`purescript-eff`](https://github.com/purescript-deprecated/purescript-eff) has been deprecated in favor of [`purescript-effect`](https://github.com/purescript/purescript-effect) (for effects that don't require row types)